### PR TITLE
Write pnpm cooldown to pnpm's own global config to prevent npm 12 breakage

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -32,6 +32,10 @@ jobs:
         with:
           node-version: '24'
 
+      - name: Install pnpm (macOS only; Linux installs pnpm inside the Docker container)
+        if: runner.os == 'macOS'
+        run: npm install -g pnpm
+
       - name: Smoke test
         run: |
           set -euo pipefail
@@ -40,8 +44,8 @@ jobs:
           if [[ "${{ runner.os }}" == "Linux" ]]; then
             docker run --rm -i \
               -v "$GITHUB_WORKSPACE/cooldowns.sh:/usr/local/bin/cooldowns.sh:ro" \
-              debian:stable-slim \
-              bash -s /etc/profile.d/cooldowns.sh < "$script"
+              node:lts-slim \
+              bash -c 'npm install -g pnpm --quiet && bash -s /etc/profile.d/cooldowns.sh' < "$script"
           else
             export PATH="$GITHUB_WORKSPACE:$PATH"
             chmod +x "$GITHUB_WORKSPACE/cooldowns.sh"

--- a/ci/smoke-test.sh
+++ b/ci/smoke-test.sh
@@ -26,6 +26,18 @@ if [[ ! -f "$bunfig" ]]; then
   verify_bunfig_mode_preserved=true
 fi
 
+# pnpm checks that its global bin directory is in PATH before accepting config
+# commands. With an isolated HOME the directory doesn't exist yet; create it
+# and add it so pnpm doesn't abort with "global bin directory ... is not in PATH".
+if command -v pnpm &>/dev/null; then
+    case "$(uname -s)" in
+        Darwin) _pnpm_bin="${HOME}/Library/pnpm/bin" ;;
+        *)      _pnpm_bin="${HOME}/.local/share/pnpm/bin" ;;
+    esac
+    mkdir -p "$_pnpm_bin"
+    export PATH="$_pnpm_bin:$PATH"
+fi
+
 configured_tools=()
 for t in pip uv npm pnpm yarn bun deno cargo; do
   set_out=$(cooldowns.sh set "$t" 7d)
@@ -34,6 +46,20 @@ for t in pip uv npm pnpm yarn bun deno cargo; do
     configured_tools+=("$t")
   fi
 done
+
+# pnpm: verify minimum-release-age landed in pnpm's own global config, not ~/.npmrc.
+if command -v pnpm &>/dev/null; then
+    pnpm_val=$(pnpm config get minimum-release-age 2>/dev/null || true)
+    [[ "$pnpm_val" == "10080" ]] || {
+        echo "smoke: pnpm minimum-release-age: expected 10080 (7 days in minutes), got '${pnpm_val}'" >&2
+        exit 1
+    }
+    if grep -q "^minimum-release-age=" "${HOME}/.npmrc" 2>/dev/null; then
+        echo "smoke: minimum-release-age must not appear in ~/.npmrc (would break npm 12)" >&2
+        exit 1
+    fi
+    echo "smoke: pnpm minimum-release-age=$pnpm_val in pnpm global config, absent from ~/.npmrc"
+fi
 
 if [[ "$verify_bunfig_mode_preserved" == true ]]; then
   bunfig_mode_after=$(file_mode_octal "$bunfig")

--- a/cooldowns.sh
+++ b/cooldowns.sh
@@ -13,6 +13,7 @@
 #   cooldowns.sh check
 #
 # Changelog:
+#   2026-05-28  Use pnpm config set --global for pnpm to avoid npm unknown-key warnings
 #   2026-05-07  Added pip 26.1+ duration format support (e.g. P3D)
 #
 # Supported tools: pip, uv, npm, pnpm, yarn, bun, deno, cargo
@@ -24,7 +25,7 @@
 #          - pip < 26.1 uses shell wrapper with absolute timestamps
 #   uv     UV_EXCLUDE_NEWER export in /etc/profile.d/cooldowns.sh (or ~/.zshrc / ~/.bashrc)
 #   npm    min-release-age in ~/.npmrc
-#   pnpm   minimum-release-age in ~/.npmrc
+#   pnpm   minimum-release-age via pnpm config set --global (writes to pnpm's global rc)
 #   yarn   YARN_NPM_MINIMAL_AGE_GATE export in /etc/profile.d/cooldowns.sh (or ~/.zshrc / ~/.bashrc)
 #   bun    minimumReleaseAge in ~/.bunfig.toml
 #   deno   Aliases in /etc/profile.d/cooldowns.sh (or ~/.zshrc / ~/.bashrc)
@@ -352,7 +353,26 @@ set_npm() {
 }
 
 set_pnpm() {
-    set_npmrc_key pnpm minimum-release-age "$1"
+    local days="$1"
+    if ! command -v pnpm &>/dev/null; then
+        echo "pnpm: not installed, skipping"
+        return
+    fi
+    local duration
+    duration=$(duration_for_tool "$days" pnpm)
+
+    local existing
+    existing=$(pnpm config get minimum-release-age 2>/dev/null || true)
+    if [[ -n "$existing" && "$existing" != "undefined" ]]; then
+        echo "pnpm: minimum-release-age is already set to '$existing', skipping"
+        return
+    fi
+
+    pnpm config set minimum-release-age "$duration" --global
+    local globalconfig
+    globalconfig=$(pnpm config get globalconfig 2>/dev/null || true)
+    [[ -z "$globalconfig" || "$globalconfig" == "undefined" ]] && globalconfig="pnpm global config"
+    echo "pnpm: set minimum-release-age=$duration in $globalconfig"
 }
 
 set_yarn() {
@@ -694,7 +714,12 @@ check_npm() {
 }
 
 check_pnpm() {
-    check_npmrc_key pnpm minimum-release-age && return
+    local val
+    val=$(pnpm config get minimum-release-age 2>/dev/null || true)
+    if [[ -n "$val" && "$val" != "undefined" ]]; then
+        record pnpm $STATUS_OK "minimum-release-age=$val (pnpm global config)"
+        return
+    fi
     record pnpm $STATUS_MISSING "no cooldown configured"
 }
 
@@ -772,7 +797,7 @@ tool_is_relevant() {
         uv)    [[ -f "${HOME}/.config/uv/uv.toml" || -n "${UV_EXCLUDE_NEWER:-}" ]] && return 0
                find_in_profiles "UV_EXCLUDE_NEWER=" &>/dev/null && return 0 ;;
         npm)   [[ -f "${HOME}/.npmrc" ]] && grep -q "min-release-age" "${HOME}/.npmrc" 2>/dev/null && return 0 ;;
-        pnpm)  [[ -f "${HOME}/.npmrc" ]] && grep -q "minimum-release-age" "${HOME}/.npmrc" 2>/dev/null && return 0 ;;
+        pnpm)  command -v pnpm &>/dev/null && pnpm config get minimum-release-age 2>/dev/null | grep -qv "^undefined$" && return 0 ;;
         bun)   [[ -f "${HOME}/.bunfig.toml" ]] && return 0 ;;
         cargo) [[ -n "${COOLDOWN_MINUTES:-}" ]] && return 0
                find_in_profiles "COOLDOWN_MINUTES=" &>/dev/null && return 0 ;;

--- a/cooldowns.sh
+++ b/cooldowns.sh
@@ -670,19 +670,6 @@ check_uv() {
     record uv $STATUS_MISSING "no cooldown configured"
 }
 
-check_npmrc_key() {
-    local tool="$1" key="$2"
-    local npmrc="${HOME}/.npmrc"
-    local val
-    if [[ -f "$npmrc" ]]; then
-        if val=$(extract_kv "$key" "$npmrc"); then
-            record "$tool" $STATUS_OK "${key}=$val in $npmrc"
-            return 0
-        fi
-    fi
-    return 1
-}
-
 check_npm() {
     local npm_major=""
     if command -v npm &>/dev/null; then


### PR DESCRIPTION
 `set_pnpm` was routing through `set_npmrc_key`, which hardcodes `~/.npmrc`. `minimum-release-age` is a pnpm-only key, npm has never recognised it. npm currently warns about it; npm 12 will throw an error instead, breaking npm install for anyone who has `minimum-release-age` set in their `~/.npmrc`

pnpm's global rc file is platform-dependent (`~/Library/Preferences/pnpm/rc` on macOS, `~/.config/pnpm/rc` on Linux), so rather than hardcoding a path, this uses `pnpm config set --global` and `pnpm config get`, which let pnpm handle the path itself.

 `check_pnpm` is updated to use `pnpm config get` for the same reason. 

  Verified locally:
  - `pnpm config get minimum-release-age` confirms the value is set after `cooldowns.sh set pnpm 3d`
  - `~/.npmrc` no longer contains `minimum-release-age`; no npm warning is produced
  - Setting the cooldown to 10 years and running `pnpm add typescript` installed 1.8.10 instead of 6.0.3, confirming pnpm enforces the setting at install time

Fixes #10 