### PR TITLE
Use properties lexer for Scala Steward HOCON snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ PRs for JVM projects. Despite its name, it works with multiple build tools (sbt,
 others). It added a cooldown feature in version 0.38.0, with more detailed configuration in 0.38.1.
 Cooldowns are configured per-repository in a `.scala-steward.conf` file at the root of the project:
 
-```hocon
+```properties
 updates.cooldown = {
   minimumAge = "3 days"
 }
@@ -310,7 +310,7 @@ younger than `minimumAge`.
 
 You can also override the cooldown for specific dependencies via `dependencyOverrides`:
 
-```hocon
+```properties
 updates.cooldown = {
   minimumAge = "3 days"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -305,7 +305,7 @@ PRs for JVM projects. Despite its name, it works with multiple build tools (sbt,
 others). It added a cooldown feature in version 0.38.0, with more detailed configuration in 0.38.1.
 Cooldowns are configured per-repository in a `.scala-steward.conf` file at the root of the project:
 
-```hocon
+```properties
 updates.cooldown = {
   minimumAge = "3 days"
 }
@@ -316,7 +316,7 @@ younger than `minimumAge`.
 
 You can also override the cooldown for specific dependencies via `dependencyOverrides`:
 
-```hocon
+```properties
 updates.cooldown = {
   minimumAge = "3 days"
 }


### PR DESCRIPTION
## Summary
- The Scala Steward config blocks (added in #9) were tagged ` ```hocon `, but Pygments has no HOCON lexer, so they fell back to plain `language-text` with no highlighting.
- Switching the fence to ` ```properties ` gives the closest available highlighting (key, `=`, quoted strings) without needing a custom lexer.
- Properties is line-based and won't visually distinguish `{`/`}`/`[`/`]` as structural braces, but it's a clear improvement over no highlighting.

## Test plan
- [x] `uv run --with zensical zensical build` succeeds
- [x] Built `site/index.html` shows `language-properties` with Pygments token spans on the Scala Steward blocks
- [x] `diff <(sed '1,/^---$/d' docs/index.md) README.md` is clean (files in sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)