### PR TITLE
fix: detect sed FLAVOR, not OS, for -i semantics (silent failure on macOS with gnu-sed in PATH)

### DIFF
--- a/cooldowns.sh
+++ b/cooldowns.sh
@@ -52,16 +52,25 @@ set -euo pipefail
 #   date_to_epoch    YYYY-MM-DD -> epoch seconds
 #   _date_days_ago   emits a `date ...` command string for "N days ago in UTC"
 #   copy_mode_from   chmod DEST to SRC's mode (mktemp files are often 0600)
+# Detect sed FLAVOR (not OS) -- BSD and GNU sed disagree on -i semantics:
+#   BSD sed:  -i SUFFIX     ('' means no backup, requires the empty arg)
+#   GNU sed:  -i[SUFFIX]    (no space; passing -i '' treats '' as the script)
+# Macs commonly have GNU sed in PATH (brew install gnu-sed), so OSTYPE alone
+# is not enough -- ask sed itself.
+if sed --version 2>/dev/null | grep -q "GNU sed"; then
+    SED_INPLACE=(sed -i)
+else
+    SED_INPLACE=(sed -i '')
+fi
+
 case "$OSTYPE" in
     darwin*|*bsd*)
-        SED_INPLACE=(sed -i '')
         date_to_epoch()   { date -j -f '%Y-%m-%d' "$1" +%s 2>/dev/null || echo ""; }
         _date_days_ago()  { echo "date -u -v-${1}d '+%Y-%m-%dT%H:%M:%SZ'"; }
         # macOS chmod has no --reference; %OLp is permission bits (not full st_mode).
         copy_mode_from() { local src="$1" dest="$2"; chmod "$(stat -f %OLp "$src")" "$dest"; }
         ;;
     *)
-        SED_INPLACE=(sed -i)
         date_to_epoch()   { date -d "$1" +%s 2>/dev/null || echo ""; }
         _date_days_ago()  { echo "date -u -d '$1 days ago' '+%Y-%m-%dT%H:%M:%SZ'"; }
         # GNU chmod: clone mode from SRC (see `chmod --help`).


### PR DESCRIPTION
## Summary

On macOS with GNU sed in `$PATH` (a common setup — `brew install gnu-sed` prepends `/opt/homebrew/opt/gnu-sed/libexec/gnubin` to PATH), `cooldowns.sh set <pip|uv|yarn> <n>d` fails with:

```
sed: can't read /^# cooldowns:pip:start$/,/^# cooldowns:pip:end$/d: No such file or directory
```

…and silently does **not** write the configured cooldown. `cooldowns.sh check` then reports `MISS    pip      no cooldown configured`, leaving the user without supply-chain protection.

## Root cause

`SED_INPLACE` is selected by `$OSTYPE`:

```bash
case "$OSTYPE" in
    darwin*|*bsd*) SED_INPLACE=(sed -i '') ;;   # BSD form
    *)             SED_INPLACE=(sed -i) ;;       # GNU form
esac
```

But BSD sed and GNU sed have incompatible `-i` semantics:

| Implementation | Syntax | Behavior on `sed -i '' 'script' file` |
|---|---|---|
| **BSD sed** | `-i SUFFIX` | `''` = no backup; `'script'` is script; `file` is input |
| **GNU sed** | `-i[SUFFIX]` (no space) | `-i` already in-place; `''` is taken as the script; `'script'` becomes the input file |

If the user has installed GNU sed via Homebrew (so `sed` resolves to gnu-sed), the BSD-style call produces the misleading error above. This is not a rare configuration — `gnu-sed` is widely recommended for macOS shell-portability reasons.

## Fix

Detect the sed flavor at startup by asking `sed --version` (GNU prints its version banner; BSD sed errors out):

```bash
if sed --version 2>/dev/null | grep -q "GNU sed"; then
    SED_INPLACE=(sed -i)
else
    SED_INPLACE=(sed -i '')
fi
```

Keep `$OSTYPE` for the parts that are genuinely OS-specific (`date`, `stat`, `chmod` flags).

## Verified

```
# Before fix (macOS, gnu-sed in PATH):
$ cooldowns.sh set pip 7d
sed: can't read /^# cooldowns:pip:start$/,/^# cooldowns:pip:end$/d: No such file or directory
$ grep -c "cooldowns:pip:start" ~/.zshrc
0

# After fix:
$ cooldowns.sh set pip 7d
pip: set PIP_UPLOADED_PRIOR_TO="P7D" in /Users/rich/.zshrc
$ grep -c "cooldowns:pip:start" ~/.zshrc
1

# Idempotent (clean_previous now works):
$ cooldowns.sh set pip 7d
pip: set PIP_UPLOADED_PRIOR_TO="P7D" in /Users/rich/.zshrc
$ grep -c "cooldowns:pip:start" ~/.zshrc
1
```

Tested on macOS 14 (Sonoma) with both BSD sed (default `/usr/bin/sed`) and GNU sed (`brew install gnu-sed`); plus Linux (GNU sed) — all three paths produce the correct in-place edit.

## Why this matters

cooldowns is a security tool. A silent failure on a common configuration means users *believe* they've enabled the cooldown defense but actually haven't. Worth a fast turnaround.

Happy to adjust the detection idiom (e.g., shell out to `sed --help` instead, or test the behavior empirically) if you'd prefer a different approach.