### PR TITLE
make shebang line more portable

### DIFF
--- a/cooldowns.sh
+++ b/cooldowns.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # cooldowns.sh -- set and check dependency cooldown configurations
 #


### PR DESCRIPTION
This is needed when the bash is not in path, e.g. nixos machines